### PR TITLE
Increase the maximum ticket size to account for AD PAC

### DIFF
--- a/src/api/auks/auks_cred.h
+++ b/src/api/auks/auks_cred.h
@@ -84,7 +84,7 @@
 #define AUKS_CRED_INVALID_TIME       0
 #define AUKS_CRED_FILE_MAX_LENGTH  128
 
-#define AUKS_CRED_DATA_MAX_LENGTH 4096
+#define AUKS_CRED_DATA_MAX_LENGTH 32768
 
 typedef struct auks_cred_info {
 	char principal[AUKS_PRINCIPAL_MAX_LENGTH + 1];

--- a/src/auksd/auksd.c
+++ b/src/auksd/auksd.c
@@ -483,7 +483,7 @@ int auksd_main_loop(auksd_engine_t* engine)
 	int queued_item_nb;
 	int launched_worker_nb=0;
 	pthread_attr_t worker_attr;
-	size_t worker_stacksize= 3 * PTHREAD_STACK_MIN ;
+	size_t worker_stacksize= 5 * PTHREAD_STACK_MIN ;
 
 	auksd_worker_args_t* worker_args;
 


### PR DESCRIPTION
32K should be sufficient for most deployments, see [Microsoft documentation](https://github.com/MicrosoftDocs/SupportArticles-docs/blob/main/support/windows-server/windows-security/kerberos-authentication-problems-if-user-belongs-to-groups.md).