### PR TITLE
Add support for a HelperScript option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream8
+FROM quay.io/almalinuxorg/almalinux:8
 
 RUN yum -y update; yum install -y autoconf automake libtool\
         libtirpc libtirpc-devel krb5-devel krb5-workstation\

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN autoreconf -fvi && ./configure && make clean && make && make install
 
 COPY fixtures/krb5.conf /etc/krb5.conf
 COPY fixtures/auks* /conf/
-
+COPY fixtures/renewer_script.sh /usr/local/bin/renewer_script.sh
 COPY fixtures/entrypoint_*.sh /usr/local/bin
 RUN chmod 0750 /usr/local/bin/entrypoint_*.sh
 

--- a/HOWTO
+++ b/HOWTO
@@ -463,3 +463,17 @@ in mind, so it is better to describe the set up with 3 nodes.
     srun: error: compute: task 0: Exited with exit code 1
     $ 
 
+> Integration with AFS, EOS, $thing
+
+Filesystems (or other components) may want to leverage kerberos credentials for access, but it is often necessary to carry out additional steps in order to obtain the right authentication tokens.
+For instance, for AFS access, running `aklog` (or equivalent) is necessary to obtain AFS authentication tokens. CERN's EOS needs to generate similar auth tokens with `eosfusebind`, etc.
+Auks provides the option to run a user-provided helper script that runs the desired additional steps.
+
+This helper script will be called:
+
+1. After plugin initialisation, right after obtaining a valid kerberos ticket.
+
+2. Each time credential renewal has taken place.
+
+To use this feature, add a `HelperScript` key in the api section of the auks config (at least for the workernodes where renewal is happening) pointing to an executable to be run as described above.
+This executable will be run as the user who submitted the Slurm job.

--- a/compose.yaml
+++ b/compose.yaml
@@ -19,6 +19,7 @@ services:
   kdc:
     image: quay.io/cea-hpc/krb5-kdc-server-example-com
     domainname: example.com
+    hostname: kdc
     healthcheck:
       test: ["CMD", "kadmin.local", "list_principals"]
       interval: 10s

--- a/doc/man/man5/auks.conf.5
+++ b/doc/man/man5/auks.conf.5
@@ -131,7 +131,12 @@ The default is \fB/dev/stdout\fR.
 \fBDebugLevel\fR
 specifies the level of debug to use. The default is \fB0\fR which 
 means no debug message.
-
+.TP
+\fBHelperScript\fR
+optional path to an executable to run during renewal and first cred get operations.
+This executable will have the corresponding KRB5CCNAME environment variable set
+to enable kerberos integration with other systems (e.g. to run aklog for AFS).
+.TP
 
 .SH "AUKSD CONFIGURATION"
 .LP

--- a/etc/auks.conf.example
+++ b/etc/auks.conf.example
@@ -52,6 +52,9 @@ api {
  DebugFile          = 	"/tmp/auksapi.log" ;
  DebugLevel         = 	"0" ;
 
+ # Helper Script
+ HelperScript = "";
+ 
 }
 
 #-

--- a/fixtures/auks.conf
+++ b/fixtures/auks.conf
@@ -52,7 +52,7 @@ api {
  DebugFile          = 	"/tmp/auksapi.log" ;
  DebugLevel         = 	"5" ;
 
- HelperScript       =   "";
+ HelperScript       =   "/usr/local/bin/renewer_script.sh";
 }
 
 #-
@@ -118,6 +118,7 @@ renewer {
 
  # Min Lifetime for credentials to be renewed
  # This value is also used as the grace trigger to renew creds
- MinLifeTime        = "600" ;
+ # In the container the lifetime is 10 hours (10*3600 - 1)
+ MinLifeTime        = "35999" ;
 
 }

--- a/fixtures/auks.conf
+++ b/fixtures/auks.conf
@@ -52,6 +52,7 @@ api {
  DebugFile          = 	"/tmp/auksapi.log" ;
  DebugLevel         = 	"5" ;
 
+ HelperScript       =   "";
 }
 
 #-

--- a/fixtures/entrypoint_auks_client.sh
+++ b/fixtures/entrypoint_auks_client.sh
@@ -10,7 +10,7 @@ fi
 $KADMIN ktadd -k /etc/krb5.keytab host/$(hostname -f)@EXAMPLE.COM
 
 klist -kt
-kinit -k
+kinit -k host/$(hostname -f)@EXAMPLE.COM
 
 export KRB5_TRACE=/dev/stderr
 exec $@

--- a/fixtures/entrypoint_auksd.sh
+++ b/fixtures/entrypoint_auksd.sh
@@ -9,15 +9,15 @@ fi
 
 $KADMIN ktadd -k /etc/krb5.keytab host/$(hostname -f)@EXAMPLE.COM
 
-if ! $KADMIN list_principals | grep -w auks/$(hostname -f)@EXAMPLE.COM
+if ! $KADMIN list_principals | grep -w auks/auks.example.com@EXAMPLE.COM
 then
-$KADMIN add_principal -randkey auks/$(hostname -f)@EXAMPLE.COM
+$KADMIN add_principal -randkey auks/auks.example.com@EXAMPLE.COM
 fi
 
-$KADMIN ktadd -k /etc/krb5.keytab auks/$(hostname -f)@EXAMPLE.COM
+$KADMIN ktadd -k /etc/krb5.keytab auks/auks.example.com@EXAMPLE.COM
 
 klist -kt
-kinit -k
+kinit -k host/$(hostname -f)@EXAMPLE.COM
 
 export KRB5_TRACE=/dev/stderr
 exec /usr/local/sbin/auksd -F -ddd -vvv -f /conf/auks.conf

--- a/fixtures/renewer_script.sh
+++ b/fixtures/renewer_script.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+touch /tmp/renewed

--- a/src/api/auks/auks_api.c
+++ b/src/api/auks/auks_api.c
@@ -76,6 +76,8 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <sys/types.h>
+#include <sys/wait.h>
 
 #include "xternal/xstream.h"
 
@@ -697,12 +699,69 @@ exit:
 	return fstatus;
 }
 
+int auks_api_run_helper(char *helper_script, char *auks_credcache, uid_t uid, gid_t gid)
+{
+	int helper_pid;
+
+	if (helper_script == NULL) {
+		auks_log3("No helper script provided");
+		return AUKS_SUCCESS; /* More of a warning than an error */
+	}
+
+	/* Launch helper renewer script. */
+
+	helper_pid = fork();
+	if (helper_pid == -1) {
+		auks_log2("unable to launch helper renewer script");
+		return AUKS_ERROR;
+	}
+	else if (helper_pid == 0) {
+		/* If we just fork() and exec(), the script will end up with uid=0 and gid=0.
+		 * Therefore, restore uid=0 privileges temporarily so that we can call setgid
+		 * and setuid for a full privilege drop. */
+		seteuid(getuid());
+		setegid(getgid());
+
+		if (setgid(gid)) {
+			auks_log2("unable to switch to user gid: %u", gid);
+			goto helper_fail;
+		}
+		if (setuid(uid) < 0) {
+			auks_log2("unable to switch to user uid: %u", uid);
+			goto helper_fail;
+		}
+
+		auks_log3("Running helper script %s as uid %u gid %u", helper_script, uid, gid);
+
+		char *argv[2];
+		argv[0] = helper_script;
+		argv[1] = NULL;
+		if (auks_credcache != NULL)
+			setenv("KRB5CCNAME", auks_credcache, 1);
+		execv(argv[0], argv);
+helper_fail:
+		auks_log2("unable to exec helper (%s)", argv[0]);
+		exit(0);
+	}
+	else {
+		auks_log3("helper renewer launched (pid=%u)", helper_pid);
+		waitpid(helper_pid, NULL, 0);
+		auks_log3("helper renewer exited (pid=%u)", helper_pid);
+	}
+
+	return AUKS_SUCCESS;
+}
+
 int
 auks_api_renew_cred(auks_engine_t * engine,char* cred_cache,int mode)
 {
 	int fstatus = AUKS_ERROR ;
 
 	auks_cred_t cred;
+
+	/* Obtain target uid/gid from a previous auks privilege drop */
+	uid_t uid = geteuid();
+	gid_t gid = getegid();
 
 	int loop = 1;
 
@@ -765,6 +824,7 @@ auks_api_renew_cred(auks_engine_t * engine,char* cred_cache,int mode)
 			fstatus = AUKS_SUCCESS;
 		}
 
+		auks_api_run_helper(engine->helper_script, cred_cache, uid, gid);
 	sleep:
 		if ( loop == 1 )
 			sleep(engine->renewer_delay);

--- a/src/api/auks/auks_api.h
+++ b/src/api/auks/auks_api.h
@@ -314,6 +314,21 @@ auks_api_send_cred(auks_engine_t * engine,uid_t uid);
  */
 int
 auks_api_receive_cred(auks_engine_t * engine,char* cred_cache);
+
+/*!
+ * \brief Run helper script as user
+ *
+ * \param helper_script path to the script to be exec'ed
+ * \param auks_credcache ccache credential file to set for helper_script
+ * \param uid user uid to drop privileges to
+ * \param gid user gid to drop privileges to
+ *
+ * \retval AUKS_SUCCESS
+ * \retval AUKS_ERROR
+ */
+int
+auks_api_run_helper(char *helper_script, char *auks_credcache, uid_t uid, gid_t gid);
+
 /*!
  * @}
 */

--- a/src/api/auks/auks_engine.c
+++ b/src/api/auks/auks_engine.c
@@ -622,8 +622,12 @@ auks_engine_init_from_config_file(auks_engine_t * engine, char *conf_file)
 
 		/* read helper script value */
 		helper_script = config_GetKeyValueByName(config, i, "HelperScript");
-		if (helper_script == NULL)
+		if (helper_script == NULL || strlen(helper_script) == 0) {
 			helper_script = DEFAULT_AUKS_HELPER_SCRIPT;
+		} else if (access(helper_script, X_OK) != 0) {
+			auks_log("%s helper script is not executable, setting NULL instead", helper_script);
+			helper_script = DEFAULT_AUKS_HELPER_SCRIPT;
+		}
 
 		valid_block_nb++;
 

--- a/src/api/auks/auks_engine.c
+++ b/src/api/auks/auks_engine.c
@@ -173,7 +173,8 @@ auks_engine_init(auks_engine_t * engine,
 		 char* renewer_debugfile,int renewer_debuglevel,
 		 time_t renewer_delay,
 		 time_t renewer_minlifetime,
-		 bool syslog)
+		 bool syslog,
+		 char *helper_script)
 {
 	int fstatus = AUKS_ERROR ;
 
@@ -238,6 +239,7 @@ auks_engine_init(auks_engine_t * engine,
 	engine->renewer_delay = renewer_delay;
 	engine->renewer_minlifetime = renewer_minlifetime;
 
+	init_strdup(engine->helper_script, helper_script);
 
 	if (engine->primary_hostname == NULL ||
 	    engine->primary_address == NULL ||
@@ -411,6 +413,8 @@ auks_engine_init_from_config_file(auks_engine_t * engine, char *conf_file)
 	char *delay_str;
 	char *nat_str;
 	
+	char *helper_script;
+
 	long int ll, dl, rnb, timeout, delay;
 
 	bool syslog;
@@ -616,6 +620,11 @@ auks_engine_init_from_config_file(auks_engine_t * engine, char *conf_file)
 		  }
 		}
 
+		/* read helper script value */
+		helper_script = config_GetKeyValueByName(config, i, "HelperScript");
+		if (helper_script == NULL)
+			helper_script = DEFAULT_AUKS_HELPER_SCRIPT;
+
 		valid_block_nb++;
 
 	}
@@ -698,7 +707,8 @@ auks_engine_init_from_config_file(auks_engine_t * engine, char *conf_file)
 					   renewer_lfile,renewer_ll,
 					   renewer_dfile,renewer_dl,
 					   renewer_delay,renewer_minlifetime,
-					   syslog);
+					   syslog,
+					   helper_script);
 		
 	}
 	

--- a/src/api/auks/auks_engine.h
+++ b/src/api/auks/auks_engine.h
@@ -117,6 +117,7 @@
 #define DEFAULT_AUKSD_LOGLEVEL          1
 #define DEFAULT_AUKSD_DEBUGFILE         "/var/log/auksd.log"
 #define DEFAULT_AUKSD_DEBUGLEVEL        0
+#define DEFAULT_AUKS_HELPER_SCRIPT	NULL
 
 #define DEFAULT_AUKSD_THREADS_NB       10
 #define DEFAULT_AUKSD_QUEUE_SIZE       50
@@ -171,6 +172,7 @@ typedef struct auks_engine {
 	int retries;
 	time_t timeout;
 	time_t delay;
+	char *helper_script;
 
 	int nat_traversal;
 
@@ -232,6 +234,8 @@ typedef struct auks_engine {
  * \param renewer_minlifetime min lifetime for a cred to be renewed by the
  *        renewer
  *
+ * \param helper_script optional path to helper script to run during cred renewal
+ *
  * \retval AUKS_SUCCESS on success
  * \retval AUKS_ERROR on failure
  *  
@@ -255,7 +259,8 @@ auks_engine_init(auks_engine_t * engine,
 		 char* renewer_debugfile,int renewer_debuglevel,
 		 time_t renewer_delay,
 		 time_t renewer_minlifetime,
-		 bool syslog);
+		 bool syslog,
+		 char *helper_script);
 
 /*!
  * \brief Initialize auks engine structure from a configuration file

--- a/src/plugins/slurm/slurm-spank-auks.c
+++ b/src/plugins/slurm/slurm-spank-auks.c
@@ -635,7 +635,7 @@ spank_auks_remote_init (spank_t sp, int ac, char *av[])
 		xerror("unable to set KRB5CCNAME env var");
 
 	/* fire helper script for the first time */
-	auks_api_run_helper(engine.helper_script, auks_credcache, uid, gid);
+	auks_api_run_helper(auks_engine.helper_script, auks_credcache, uid, gid);
 
  out_cred:
 	/* free auks cred */

--- a/src/plugins/slurm/slurm-spank-auks.c
+++ b/src/plugins/slurm/slurm-spank-auks.c
@@ -634,6 +634,9 @@ spank_auks_remote_init (spank_t sp, int ac, char *av[])
 	if ( fstatus != 0 )
 		xerror("unable to set KRB5CCNAME env var");
 
+	/* fire helper script for the first time */
+	auks_api_run_helper(engine.helper_script, auks_credcache, uid, gid);
+
  out_cred:
 	/* free auks cred */
 	auks_cred_free_contents(&cred);

--- a/tests/simple.bats
+++ b/tests/simple.bats
@@ -27,7 +27,7 @@ function teardown() {
 }
 
 @test "Ping as host" {
-    kinit -k
+    kinit -k host/$(hostname -f)@EXAMPLE.COM
     auks -f /conf/auks.conf -p
     auks -f /conf/auks.conf --ping
 }


### PR DESCRIPTION
(originally submitted here https://github.com/hautreux/auks/pull/63)

This MR adds support for a HelperScript option in the [api] config section to be run at the first "auks cred get" and after each renewal.

This has been tested to work in our production environment just fine with AFS and EOS.

I think I've added the relevant bits of docs, headers and comments, but let me know if I've left anything out that should be in there as well.