### PR TITLE
Fix auks api ccache issue with >= krb5-1.18

### DIFF
--- a/src/api/auks/auks_api.c
+++ b/src/api/auks/auks_api.c
@@ -743,15 +743,16 @@ auks_api_renew_cred(auks_engine_t * engine,char* cred_cache,int mode)
 		/* store renewed cred */
 		fstatus = auks_cred_store(&cred,cred_cache);
 		if ( fstatus != AUKS_SUCCESS ) {
-			auks_log2("unable to store cred in file '%s' : %s",
-				  cred_cache,auks_strerror(fstatus));
+			auks_log2("unable to store cred '%s' : %s",
+				  (cred_cache==NULL)?"default file":cred_cache,
+				  auks_strerror(fstatus));
 			fstatus = AUKS_ERROR_API_REPLY_PROCESSING ;
 			loop=0;
 			goto end_loop;
 		}
 		else {
-			auks_log3("auks cred successfully stored in file '%s'",
-				  cred_cache);
+			auks_log3("auks cred successfully stored in %s",
+				  (cred_cache==NULL)?"default file":cred_cache);
 			fstatus = AUKS_SUCCESS;
 		}
 

--- a/src/api/auks/auks_krb5_stream.c
+++ b/src/api/auks/auks_krb5_stream.c
@@ -842,6 +842,8 @@ auks_krb5_stream_init_base(auks_krb5_stream_t * kstream, int stream,int flags)
 	kstream->context_flag = 1;
 	auks_log("context initialization succeed");
 
+	auks_krb5_set_default_name(kstream->context);
+
 	/* kerberos : connection authentication context */
 	kstatus = krb5_auth_con_init(kstream->context,&kstream->auth_context);
 	if (kstatus) {


### PR DESCRIPTION
Fixes issues with modern krb5 libraries.
The main issue is that starting with krb5-1.18, seteuid processes ignore KRB5CCNAME in krb5_cc_default(), and therefore the default needs to be set explicitly.

This issue has been described here https://github.com/hautreux/auks/issues/61#issuecomment-1049683298