### PR TITLE
Add UseSyslog config option

### DIFF
--- a/doc/man/man5/auks.conf.5
+++ b/doc/man/man5/auks.conf.5
@@ -119,6 +119,11 @@ The default is \fB/dev/stdout\fR.
 specifies the level of verbosity to use. The default is \fB0\fR which 
 means no log message.
 .TP
+\fBUseSyslog\fR
+optional flag that specifies that the logs should be written to the system's
+native log. Any value other than 0 will be interpreted as enabled.
+The default is 0 (disabled).
+.TP
 \fBDebugFile\fR
 specifies the file in which to put AUKS debug details.
 The default is \fB/dev/stdout\fR.

--- a/src/api/auks/auks_engine.c
+++ b/src/api/auks/auks_engine.c
@@ -381,6 +381,7 @@ auks_engine_init_from_config_file(auks_engine_t * engine, char *conf_file)
 	char *lfile;
 	char *dfile;
 	
+	char *syslog;
 	char *ll_str;
 	char *dl_str;
 	char *rnb_str;
@@ -574,6 +575,13 @@ auks_engine_init_from_config_file(auks_engine_t * engine, char *conf_file)
 			dl = strtol(dl_str, NULL, 10);
 		if (dl == LONG_MIN || dl == LONG_MAX)
 			dl = DEFAULT_AUKS_DEBUGLEVEL;
+
+		syslog = config_GetKeyValueByName(config, i, "UseSyslog");
+		if (syslog != NULL) {
+			ll = strtol(syslog, NULL, 10);
+			if (ll != LONG_MIN && ll != LONG_MAX && ll != 0)
+				xverbose_usesyslog();
+		}
 
 		valid_block_nb++;
 


### PR DESCRIPTION
Enabling logging in the workers to get the logging output from "auks -R" means that all of this log goes to stdout, i.e. the user's job output. This is not desirable if you just want to have the auks logs enabled but not user-visible.

This MR introduces a new config option "UseSyslog", in the [api] section of auks.conf. When enabled, logs are written to the system log.

Choosing appropriate logging priority was difficult because while auks_log2 is generally used for errors, this same level is also used during initialisation in auks_engine, which makes these initialisation messages appear with error prio. IMHO having initialisation messages with this priority is something that should be fixed separately.

In practice, this enables a more verbose logging in production without confusing end-users, and makes auks debugging much easier.